### PR TITLE
Deprecate resolve function and allow strings to local icon dirs

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -44,7 +44,7 @@ export default defineConfig({
     plugins: [
       ion({
         icons: {
-          iconDir: resolve('./src/icons', import.meta.url),
+          iconDir: './src/icons',
         },
         footer: {
           text: '©️ Louis Escher 2025',

--- a/apps/docs/src/content/docs/changelog.mdx
+++ b/apps/docs/src/content/docs/changelog.mdx
@@ -2,6 +2,35 @@
 title: "Changelog"
 ---
 
+## v2.1.1 (Jan. 15, 2025)
+
+### Non-Breaking Changes
+
+Starting with this release, you no longer need to use the `resolve` function exported by the plugin to resolve the path to your local icon directory:
+
+```js del={11} ins={12}
+import { ion, resolve } from "starlight-ion-theme";
+
+export default defineConfig({
+  // ...
+  integrations: [
+    starlight({
+      // ...
+      plugins: [
+        ion({
+          icons: {
+            iconPath: resolve("./src/icons", import.meta.url),
+            iconPath: "./src/icons",
+          },
+        })
+      ]
+    })
+  ]
+});
+```
+
+It is recommended to stop using the function, as it has been marked as deprecated. For compatibility reasons, the function will still be exported from the package until the next minor release.
+
 ## v2.1.0 (Jan. 12, 2025)
 
 ### New Features

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -45,7 +45,7 @@ First, create a directory that will contain all of your icons, for example `src/
 After you've created the directory, you need to tell Ion where to find the icons. You can do this by specifying the `icons.iconPath` option in your `astro.config.mjs`:
 
 ```js
-import { ion, resolve } from "starlight-ion-theme";
+import { ion } from "starlight-ion-theme";
 
 export default defineConfig({
   // ...
@@ -55,7 +55,7 @@ export default defineConfig({
       plugins: [
         ion({
           icons: {
-            iconPath: resolve("./src/icons", import.meta.url)
+            iconPath: "./src/icons"
           },
         })
       ]
@@ -63,8 +63,6 @@ export default defineConfig({
   ]
 });
 ```
-
-Make sure to use the `resolve` function to resolve the path to the icons directory. The second argument (in most cases) should be `import.meta.url`. When no icon path is set, icons will not be loaded.
 
 #### External Icons
 
@@ -130,11 +128,7 @@ import HeaderBadge from 'starlight-ion-theme/components/HeaderBadge.astro';
 - Type: `AstroIconOptions | undefined`
 - Default: `undefined`
 
-The `icons` object exposes `astro-icon`'s configuration options. Check the [astro-icon documentation](https://www.astroicon.dev) for more information. 
-
-:::danger[Using Local Icons]
-When using local icons, you must specify the `iconPath` using the `resolve` function exported by Ion. The first argument should be the path to the icons directory (e.g. `src/icons/`), and the second argument should be `import.meta.url`.
-:::
+The `icons` object exposes `astro-icon`'s configuration options. Check the [astro-icon documentation](https://www.astroicon.dev) for more information.
 
 ### `useCustomECTheme`
 - Type: `boolean | undefined`

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -1,3 +1,9 @@
+:root {
+  /* Font */
+  --sl-font: 'Space Grotesk Variable', sans-serif;
+  --sl-font-system-mono: "Space Mono", monospace;
+}
+
 /* Change font & remove ligatures for all code & the file tree */
 .expressive-code, pre, .expressive-code pre > code, code, starlight-file-tree {
   font-family: 'Space Mono', monospace !important;

--- a/package.json
+++ b/package.json
@@ -4,5 +4,6 @@
   "scripts": {
     "dev": "\"pnpm --filter docs dev\"",
     "publish": "\"pnpm --filter starlight-ion-theme publish\""
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/packages/starlight-ion-theme/index.ts
+++ b/packages/starlight-ion-theme/index.ts
@@ -99,7 +99,7 @@ function integration(pluginConfig: Config): AstroIntegration {
           'ion:globals',
           'ion-theme-globals',
 `export const icons = ${JSON.stringify(!!pluginConfig.icons)};
-export const footer = ${JSON.stringify(pluginConfig.footer)};`)
+export const footer = ${JSON.stringify(pluginConfig.footer)};`);
 
         updateConfig({
           vite: {
@@ -112,10 +112,6 @@ export const footer = ${JSON.stringify(pluginConfig.footer)};`)
 }
 
 function createPlugin(pluginConfig: Config): StarlightPlugin {
-  if (pluginConfig?.icons && pluginConfig.icons.iconDir && !path.isAbsolute(pluginConfig.icons.iconDir)) {
-    throw new Error('Please use the `resolve` function exported from \'starlight-ion-theme\' to set the `iconDir` option.');
-  }
-
 	return {
 		name: "starlight-ion-theme",
 		hooks: {

--- a/packages/starlight-ion-theme/index.ts
+++ b/packages/starlight-ion-theme/index.ts
@@ -83,6 +83,7 @@ interface Config {
  * Resolves a path relative to the base path.
  * @param path - The path to resolve.
  * @param base - The base path to resolve from. Usually `import.meta.url`.
+ * @deprecated
  */
 function resolve(path: string, base: string) {
   const { resolve } = createResolver(base);

--- a/packages/starlight-ion-theme/styles/theme.css
+++ b/packages/starlight-ion-theme/styles/theme.css
@@ -1,9 +1,5 @@
 /* Specify colors. NOTE: YOU CAN CUSTOMIZE THESE HOWEVER YOU WANT! */
 :root {
-  /* Font */
-  --sl-font: 'Space Grotesk', sans-serif;
-  --sl-font-system-mono: "Space Mono", monospace;
-
   /* Dark mode colors */
 	--sl-color-accent-low: #3c0017;
 	--sl-color-accent: #bd0249;


### PR DESCRIPTION
- Deprecates the `resolve` function exported by Ion
- Allows for strings to be used to link to local icon directories instead