### PR TITLE
Fix docs on how to use icons, make plugin options optional

### DIFF
--- a/apps/docs/src/content/docs/changelog.mdx
+++ b/apps/docs/src/content/docs/changelog.mdx
@@ -4,6 +4,10 @@ title: "Changelog"
 
 ## v2.1.2 (Jan. 25, 2025)
 
+### Bug Fixes
+
+- The plugin configuration is now optional, allowing you to use Ion without any configuration.
+
 ## v2.1.1 (Jan. 15, 2025)
 
 ### Non-Breaking Changes

--- a/apps/docs/src/content/docs/changelog.mdx
+++ b/apps/docs/src/content/docs/changelog.mdx
@@ -2,6 +2,8 @@
 title: "Changelog"
 ---
 
+## v2.1.2 (Jan. 25, 2025)
+
 ## v2.1.1 (Jan. 15, 2025)
 
 ### Non-Breaking Changes
@@ -19,8 +21,8 @@ export default defineConfig({
       plugins: [
         ion({
           icons: {
-            iconPath: resolve("./src/icons", import.meta.url),
-            iconPath: "./src/icons",
+            iconDir: resolve("./src/icons", import.meta.url),
+            iconDir: "./src/icons",
           },
         })
       ]
@@ -54,9 +56,9 @@ export default defineConfig({
       // ...
       plugins: [
         ion({
-          iconPath: resolve("./src/icons", import.meta.url),
+          iconDir: resolve("./src/icons", import.meta.url),
           icons: {
-            iconPath: resolve("./src/icons", import.meta.url)
+            iconDir: resolve("./src/icons", import.meta.url)
           },
         })
       ]

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -42,7 +42,7 @@ If you want to use an icon, you have two options:
 #### Local Icons
 First, create a directory that will contain all of your icons, for example `src/icons/`. Then, place the SVG files for the icons in that directory.
 
-After you've created the directory, you need to tell Ion where to find the icons. You can do this by specifying the `icons.iconPath` option in your `astro.config.mjs`:
+After you've created the directory, you need to tell Ion where to find the icons. You can do this by specifying the `icons.iconDir` option in your `astro.config.mjs`:
 
 ```js
 import { ion } from "starlight-ion-theme";
@@ -55,7 +55,7 @@ export default defineConfig({
       plugins: [
         ion({
           icons: {
-            iconPath: "./src/icons"
+            iconDir: "./src/icons"
           },
         })
       ]

--- a/packages/starlight-ion-theme/index.ts
+++ b/packages/starlight-ion-theme/index.ts
@@ -91,7 +91,7 @@ function resolve(path: string, base: string) {
   return resolve(path);
 }
 
-function integration(pluginConfig: Config): AstroIntegration {
+function integration(pluginConfig?: Config): AstroIntegration {
   return {
     name: 'Ion',
     hooks: {
@@ -99,8 +99,8 @@ function integration(pluginConfig: Config): AstroIntegration {
         const globals = viteVirtualModulePluginBuilder(
           'ion:globals',
           'ion-theme-globals',
-`export const icons = ${JSON.stringify(!!pluginConfig.icons)};
-export const footer = ${JSON.stringify(pluginConfig.footer)};`);
+`export const icons = ${JSON.stringify(pluginConfig ? !!pluginConfig.icons : false)};
+export const footer = ${JSON.stringify(pluginConfig?.footer || { text: "" })};`);
 
         updateConfig({
           vite: {
@@ -112,13 +112,13 @@ export const footer = ${JSON.stringify(pluginConfig.footer)};`);
   }
 }
 
-function createPlugin(pluginConfig: Config): StarlightPlugin {
+function createPlugin(pluginConfig?: Config): StarlightPlugin {
 	return {
 		name: "starlight-ion-theme",
 		hooks: {
 			setup: ({ config, updateConfig, addIntegration }) => {
         addIntegration(integration(pluginConfig));
-        addIntegration(icon(pluginConfig.icons));
+        addIntegration(icon(pluginConfig ? pluginConfig.icons : undefined));
 
         const customCss = config.customCss 
           ? ['starlight-ion-theme/styles/theme.css', ...config.customCss] 


### PR DESCRIPTION
- Fixes some incorrect documentation
- Allows Ion plugin to be used without any configuration as specified in the docs
- Closes #10 